### PR TITLE
Generate canonical assets declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,112 @@ bazel run -- @buildifier_prebuilt//:buildifier ARGS
 Checkout [the releases
 page](https://github.com/keith/buildifier-prebuilt/releases) for
 snippets for your WORKSPACE
+
+### Specify Version of Buildtools
+
+If you would like to specify a specific version of buildtools to use, you can do one of the
+following.
+
+#### Option 1: Quick and Easy
+
+Update the `buildifier_prebuilt_register_toolchains` declaration in your `WORKSPACE` file to specify
+the version.
+
+```python
+# Use buildtools version 4.2.5.
+buildifier_prebuilt_register_toolchains(
+    assets = buildtools_assets(version = "4.2.5"),
+)
+```
+
+The above example will download version 4.2.5 of the `buildtools` binaries. The only downside is
+that you will see warnings stating that a canonical version can be specified using SHA256 values.
+
+
+#### Option 2: Manually Add SHA256 Values
+
+To add SHA256 values to the declaration, add a `sha256_values` attribute and specify the values in a
+`dict` where the key is `<tool>_<platform>_<arch>` and the value is the SHA256 value.
+
+```python
+# Use buildtools version 4.2.5.
+buildifier_prebuilt_register_toolchains(
+    assets = buildtools_assets(version = "4.2.5"),
+    sha256_values = {
+        "buildifier_darwin_amd64": "757f246040aceb2c9550d02ef5d1f22d3ef1ff53405fe76ef4c6239ef1ea2cc1",
+        "buildifier_darwin_arm64": "4cf02e051f6cda18765935cb6e77cc938cf8b405064589a50fe9582f82c7edaf",
+        "buildifier_linux_amd64": "f94e71b22925aff76ce01a49e1c6c6d31f521bbbccff047b81f2ea01fd01a945",
+        "buildifier_linux_arm64": "2113d79e45efb51e2b3013c8737cb66cadae3fd89bd7e820438cb06201e50874",
+        "buildozer_darwin_amd64": "3fe671620e6cb7d2386f9da09c1de8de88b02b9dd9275cdecd8b9e417f74df1b",
+        "buildozer_darwin_arm64": "ff4d297023fe3e0fd14113c78f04cef55289ca5bfe5e45a916be738b948dc743",
+        "buildozer_linux_amd64": "e8e39b71c52318a9030dd9fcb9bbfd968d0e03e59268c60b489e6e6fc1595d7b",
+        "buildozer_linux_arm64": "96227142969540def1d23a9e8225524173390d23f3d7fd56ce9c4436953f02fc",
+    },
+)
+```
+
+The downside to this is that you will need to manually download each binary that you will use in
+your builds and calculate the SHA256 value.
+
+
+#### Option 3: Quick, Easy and Canonical
+
+We have included a utility which will generate a `buildifier_prebuilt_register_toolchains`
+declaration with the appropriate SHA256 values. If you execute it without any arguments, it will
+use the latest release of `buildtools`. Just copy and paste the declaration into your `WORKSPACE`
+file.
+
+```sh
+# Generate the declaration for the latest
+$ bazel run //tools:generate_assets_declaration
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains", "buildtools_assets")
+
+buildifier_prebuilt_register_toolchains(
+    assets = buildtools_assets(
+        version = "4.2.5",
+        names = ["buildifier", "buildozer"],
+        platforms = ["darwin", "linux"],
+        arches = ["amd64", "arm64"],
+        sha256_values = {
+            "buildifier_darwin_amd64": "757f246040aceb2c9550d02ef5d1f22d3ef1ff53405fe76ef4c6239ef1ea2cc1",
+            "buildifier_darwin_arm64": "4cf02e051f6cda18765935cb6e77cc938cf8b405064589a50fe9582f82c7edaf",
+            "buildifier_linux_amd64": "f94e71b22925aff76ce01a49e1c6c6d31f521bbbccff047b81f2ea01fd01a945",
+            "buildifier_linux_arm64": "2113d79e45efb51e2b3013c8737cb66cadae3fd89bd7e820438cb06201e50874",
+            "buildozer_darwin_amd64": "3fe671620e6cb7d2386f9da09c1de8de88b02b9dd9275cdecd8b9e417f74df1b",
+            "buildozer_darwin_arm64": "ff4d297023fe3e0fd14113c78f04cef55289ca5bfe5e45a916be738b948dc743",
+            "buildozer_linux_amd64": "e8e39b71c52318a9030dd9fcb9bbfd968d0e03e59268c60b489e6e6fc1595d7b",
+            "buildozer_linux_arm64": "96227142969540def1d23a9e8225524173390d23f3d7fd56ce9c4436953f02fc",
+        },
+    ),
+)
+```
+
+You may also specify a specific version of `buildtools` by adding it to the end of the command.
+
+```sh
+# Generate the declaration for version 4.2.3
+$ bazel run //tools:generate_assets_declaration -- 4.2.3
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains", "buildtools_assets")
+
+buildifier_prebuilt_register_toolchains(
+    assets = buildtools_assets(
+        version = "4.2.3",
+        names = ["buildifier", "buildozer"],
+        platforms = ["darwin", "linux"],
+        arches = ["amd64", "arm64"],
+        sha256_values = {
+            "buildifier_darwin_amd64": "954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663",
+            "buildifier_darwin_arm64": "9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3",
+            "buildifier_linux_amd64": "a19126536bae9a3917a7fc4bdbbf0378371a1d1683ab2415857cf53bce9dee49",
+            "buildifier_linux_arm64": "39bd9d01d3638902a1e4cef353048ed160f0575f5df1bef175bd7637386d183c",
+            "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
+            "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
+            "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
+            "buildozer_linux_arm64": "edfa964b283352ffd7503faca503de8f06dfcd1c7c96a6737e9452167e93c687",
+        },
+    ),
+)
+```
+
+NOTE: The utility uses the [GitHub CLI](https://cli.github.com/). If you haven't already done so,
+install it.

--- a/buildtools.bzl
+++ b/buildtools.bzl
@@ -142,6 +142,23 @@ _DEFAULT_ASSETS = _create_assets(version = "4.2.3", sha256_values = {
     "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
 })
 
+# _DEFAULT_ASSETS = _create_assets(
+#     version = "4.2.5",
+#     names = ["buildifier, buildozer"],
+#     platforms = ["darwin, linux"],
+#     arches = ["amd64, arm64"],
+#     sha256_values = {
+#         "buildifier_darwin_amd64": "757f246040aceb2c9550d02ef5d1f22d3ef1ff53405fe76ef4c6239ef1ea2cc1",
+#         "buildifier_darwin_arm64": "4cf02e051f6cda18765935cb6e77cc938cf8b405064589a50fe9582f82c7edaf",
+#         "buildifier_linux_amd64": "f94e71b22925aff76ce01a49e1c6c6d31f521bbbccff047b81f2ea01fd01a945",
+#         "buildifier_linux_arm64": "2113d79e45efb51e2b3013c8737cb66cadae3fd89bd7e820438cb06201e50874",
+#         "buildozer_darwin_amd64": "3fe671620e6cb7d2386f9da09c1de8de88b02b9dd9275cdecd8b9e417f74df1b",
+#         "buildozer_darwin_arm64": "ff4d297023fe3e0fd14113c78f04cef55289ca5bfe5e45a916be738b948dc743",
+#         "buildozer_linux_amd64": "e8e39b71c52318a9030dd9fcb9bbfd968d0e03e59268c60b489e6e6fc1595d7b",
+#         "buildozer_linux_arm64": "96227142969540def1d23a9e8225524173390d23f3d7fd56ce9c4436953f02fc",
+#     },
+# )
+
 buildtools = struct(
     create_asset = _create_asset,
     create_unique_name = _create_unique_name,

--- a/buildtools.bzl
+++ b/buildtools.bzl
@@ -133,15 +133,6 @@ def _create_assets(version, names = _TOOL_NAMES, platforms = _TYPICAL_PLATFORMS,
                 ))
     return assets
 
-# _DEFAULT_ASSETS = _create_assets(version = "4.2.3", sha256_values = {
-#     "buildifier_darwin_amd64": "954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663",
-#     "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
-#     "buildifier_darwin_arm64": "9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3",
-#     "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
-#     "buildifier_linux_amd64": "a19126536bae9a3917a7fc4bdbbf0378371a1d1683ab2415857cf53bce9dee49",
-#     "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
-# })
-
 _DEFAULT_ASSETS = _create_assets(
     version = "4.2.5",
     names = ["buildifier", "buildozer"],

--- a/buildtools.bzl
+++ b/buildtools.bzl
@@ -133,31 +133,31 @@ def _create_assets(version, names = _TOOL_NAMES, platforms = _TYPICAL_PLATFORMS,
                 ))
     return assets
 
-_DEFAULT_ASSETS = _create_assets(version = "4.2.3", sha256_values = {
-    "buildifier_darwin_amd64": "954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663",
-    "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
-    "buildifier_darwin_arm64": "9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3",
-    "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
-    "buildifier_linux_amd64": "a19126536bae9a3917a7fc4bdbbf0378371a1d1683ab2415857cf53bce9dee49",
-    "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
-})
+# _DEFAULT_ASSETS = _create_assets(version = "4.2.3", sha256_values = {
+#     "buildifier_darwin_amd64": "954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663",
+#     "buildozer_darwin_amd64": "edcabae1d97bdc42559d7d1d65dfe7f8970db8d95d4bc9e7bf6656a9f2fb5592",
+#     "buildifier_darwin_arm64": "9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3",
+#     "buildozer_darwin_arm64": "f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071",
+#     "buildifier_linux_amd64": "a19126536bae9a3917a7fc4bdbbf0378371a1d1683ab2415857cf53bce9dee49",
+#     "buildozer_linux_amd64": "6b4177321b770fb788b618caa453d34561b8c05081ae8b27657e527c2a3b5d52",
+# })
 
-# _DEFAULT_ASSETS = _create_assets(
-#     version = "4.2.5",
-#     names = ["buildifier, buildozer"],
-#     platforms = ["darwin, linux"],
-#     arches = ["amd64, arm64"],
-#     sha256_values = {
-#         "buildifier_darwin_amd64": "757f246040aceb2c9550d02ef5d1f22d3ef1ff53405fe76ef4c6239ef1ea2cc1",
-#         "buildifier_darwin_arm64": "4cf02e051f6cda18765935cb6e77cc938cf8b405064589a50fe9582f82c7edaf",
-#         "buildifier_linux_amd64": "f94e71b22925aff76ce01a49e1c6c6d31f521bbbccff047b81f2ea01fd01a945",
-#         "buildifier_linux_arm64": "2113d79e45efb51e2b3013c8737cb66cadae3fd89bd7e820438cb06201e50874",
-#         "buildozer_darwin_amd64": "3fe671620e6cb7d2386f9da09c1de8de88b02b9dd9275cdecd8b9e417f74df1b",
-#         "buildozer_darwin_arm64": "ff4d297023fe3e0fd14113c78f04cef55289ca5bfe5e45a916be738b948dc743",
-#         "buildozer_linux_amd64": "e8e39b71c52318a9030dd9fcb9bbfd968d0e03e59268c60b489e6e6fc1595d7b",
-#         "buildozer_linux_arm64": "96227142969540def1d23a9e8225524173390d23f3d7fd56ce9c4436953f02fc",
-#     },
-# )
+_DEFAULT_ASSETS = _create_assets(
+    version = "4.2.5",
+    names = ["buildifier", "buildozer"],
+    platforms = ["darwin", "linux"],
+    arches = ["amd64", "arm64"],
+    sha256_values = {
+        "buildifier_darwin_amd64": "757f246040aceb2c9550d02ef5d1f22d3ef1ff53405fe76ef4c6239ef1ea2cc1",
+        "buildifier_darwin_arm64": "4cf02e051f6cda18765935cb6e77cc938cf8b405064589a50fe9582f82c7edaf",
+        "buildifier_linux_amd64": "f94e71b22925aff76ce01a49e1c6c6d31f521bbbccff047b81f2ea01fd01a945",
+        "buildifier_linux_arm64": "2113d79e45efb51e2b3013c8737cb66cadae3fd89bd7e820438cb06201e50874",
+        "buildozer_darwin_amd64": "3fe671620e6cb7d2386f9da09c1de8de88b02b9dd9275cdecd8b9e417f74df1b",
+        "buildozer_darwin_arm64": "ff4d297023fe3e0fd14113c78f04cef55289ca5bfe5e45a916be738b948dc743",
+        "buildozer_linux_amd64": "e8e39b71c52318a9030dd9fcb9bbfd968d0e03e59268c60b489e6e6fc1595d7b",
+        "buildozer_linux_arm64": "96227142969540def1d23a9e8225524173390d23f3d7fd56ce9c4436953f02fc",
+    },
+)
 
 buildtools = struct(
     create_asset = _create_asset,

--- a/deps.bzl
+++ b/deps.bzl
@@ -12,12 +12,20 @@ def buildifier_prebuilt_deps():
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
 
+    # TODO: FIX ME
+
     maybe(
-        http_archive,
+        native.local_repository,
         name = "cgrindel_bazel_starlib",
-        sha256 = "9e054e423bb7674e02052e52725b41288369dd94efff963479f76fe269b5177f",
-        strip_prefix = "bazel-starlib-0.3.1",
-        urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.3.1.tar.gz",
-        ],
+        path = "/Users/chuck/code/cgrindel/bazel-starlib",
     )
+
+#     maybe(
+#         http_archive,
+#         name = "cgrindel_bazel_starlib",
+#         sha256 = "9e054e423bb7674e02052e52725b41288369dd94efff963479f76fe269b5177f",
+#         strip_prefix = "bazel-starlib-0.3.1",
+#         urls = [
+#             "http://github.com/cgrindel/bazel-starlib/archive/v0.3.1.tar.gz",
+#         ],
+#     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -12,20 +12,12 @@ def buildifier_prebuilt_deps():
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
 
-    # TODO: FIX ME
-
     maybe(
-        native.local_repository,
+        http_archive,
         name = "cgrindel_bazel_starlib",
-        path = "/Users/chuck/code/cgrindel/bazel-starlib",
+        sha256 = "fc2ee0fce914e3aee1a6af460d4ba1eed9d82e8125294d14e7d3f236d4a10a5d",
+        strip_prefix = "bazel-starlib-0.3.2",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.3.2.tar.gz",
+        ],
     )
-
-#     maybe(
-#         http_archive,
-#         name = "cgrindel_bazel_starlib",
-#         sha256 = "9e054e423bb7674e02052e52725b41288369dd94efff963479f76fe269b5177f",
-#         strip_prefix = "bazel-starlib-0.3.1",
-#         urls = [
-#             "http://github.com/cgrindel/bazel-starlib/archive/v0.3.1.tar.gz",
-#         ],
-#     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -11,3 +11,13 @@ def buildifier_prebuilt_deps():
         ],
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
     )
+
+    maybe(
+        http_archive,
+        name = "cgrindel_bazel_starlib",
+        sha256 = "9e054e423bb7674e02052e52725b41288369dd94efff963479f76fe269b5177f",
+        strip_prefix = "bazel-starlib-0.3.1",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.3.1.tar.gz",
+        ],
+    )

--- a/tests/tools_tests/BUILD
+++ b/tests/tools_tests/BUILD
@@ -1,9 +1,13 @@
+load("@cgrindel_bazel_starlib//tests:integration_test_common.bzl", "GH_ENV_INHERIT")
+
 sh_test(
     name = "generate_assets_declaration_test",
+    size = "medium",
     srcs = ["generate_assets_declaration_test.sh"],
     data = [
         "//tools:generate_assets_declaration",
     ],
+    env_inherit = GH_ENV_INHERIT,
     deps = [
         "@bazel_tools//tools/bash/runfiles",
         "@cgrindel_bazel_starlib//shlib/lib:assertions",

--- a/tests/tools_tests/BUILD
+++ b/tests/tools_tests/BUILD
@@ -1,0 +1,11 @@
+sh_test(
+    name = "generate_assets_declaration_test",
+    srcs = ["generate_assets_declaration_test.sh"],
+    data = [
+        "//tools:generate_assets_declaration",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/tests/tools_tests/generate_assets_declaration_test.sh
+++ b/tests/tools_tests/generate_assets_declaration_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+fail "IMPLEMENT ME!"

--- a/tests/tools_tests/generate_assets_declaration_test.sh
+++ b/tests/tools_tests/generate_assets_declaration_test.sh
@@ -11,6 +11,8 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# MARK - Locate Deps
+
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)

--- a/tests/tools_tests/generate_assets_declaration_test.sh
+++ b/tests/tools_tests/generate_assets_declaration_test.sh
@@ -11,6 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+
 # MARK - Locate Deps
 
 assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
@@ -18,4 +19,58 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
-fail "IMPLEMENT ME!"
+generate_assets_declaration_sh_location=buildifier_prebuilt/tools/generate_assets_declaration.sh
+generate_assets_declaration_sh="$(rlocation "${generate_assets_declaration_sh_location}")" || \
+  (echo >&2 "Failed to locate ${generate_assets_declaration_sh_location}" && exit 1)
+
+
+# MARK - Set Up a Workspace Directory
+
+# Bazel sh_binary targets expect BUILD_WORKSPACE_DIRECTORY to exist. Because
+# we are in a test, we need to fake it out.
+
+repo_dir="${PWD}/repo"
+rm -rf "${repo_dir}"
+mkdir -p "${repo_dir}"
+export "BUILD_WORKSPACE_DIRECTORY=${repo_dir}"
+
+
+# MARK - Test with Defaults
+
+actual="$( "${generate_assets_declaration_sh}" )"
+assert_match "load.*@buildifier_prebuilt//:defs.bzl" "${actual}"
+assert_match "buildifier_prebuilt_register_toolchains" "${actual}"
+assert_match "buildifier_darwin_amd64" "${actual}"
+assert_match "buildifier_linux_arm64" "${actual}"
+assert_match "buildozer_linux_arm64" "${actual}"
+assert_match "buildozer_darwin_amd64" "${actual}"
+
+
+# MARK - Test with Release Tag
+
+actual="$( "${generate_assets_declaration_sh}" "4.2.3" )"
+assert_match "version.*4.2.3" "${actual}"
+assert_match \
+  "buildifier_darwin_amd64.*954ec397089344b1564e45dc095e9331e121eb0f20e72032fcc8e94de78e5663" \
+  "${actual}"
+assert_match \
+  "buildozer_darwin_arm64.*f8d0994620dec1247328f13db1d434b6489dd007f8e9b961dbd9363bc6fe7071" \
+  "${actual}"
+
+
+# MARK - Test Changing Defaults
+
+actual="$( 
+  "${generate_assets_declaration_sh}" \
+    --reset_tools \
+    --tool buildifier \
+    --reset_platforms \
+    --platform darwin \
+    --reset_arches \
+    --arch arm64 \
+    "4.2.3" 
+)"
+assert_match "version.*4.2.3" "${actual}"
+assert_match \
+  "buildifier_darwin_arm64.*9434043897a3c3821fda87046918e5a6c4320d8352df700f62046744c4d168a3" \
+  "${actual}"

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -4,6 +4,7 @@ sh_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:env",
         "@cgrindel_bazel_starlib//shlib/lib:fail",
     ],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,9 @@
+sh_binary(
+    name = "generate_assets_declaration",
+    srcs = ["generate_assets_declaration.sh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:fail",
+    ],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -4,6 +4,7 @@ sh_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:arrays",
         "@cgrindel_bazel_starlib//shlib/lib:env",
         "@cgrindel_bazel_starlib//shlib/lib:fail",
     ],

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -23,6 +23,10 @@ env_sh="$(rlocation "${env_sh_location}")" || \
   (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
 source "${env_sh}"
 
+arrays_sh_location=cgrindel_bazel_starlib/shlib/lib/arrays.sh
+arrays_sh="$(rlocation "${arrays_sh_location}")" || \
+  (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
+source "${arrays_sh}"
 
 # MARK - Check for Required Software
 
@@ -33,21 +37,21 @@ is_installed shasum || fail "Could not find shasum."
 
 # MARK - Functions
 
-to_delim_str() {
-  local delimiter="${1}"
-  shift 1
-  printf -v joined '%s'"${delimiter}" "${@}"
-  echo "${joined%${delimiter}}"
-}
+# join_by() {
+#   local delimiter="${1}"
+#   shift 1
+#   printf -v joined '%s'"${delimiter}" "${@}"
+#   echo "${joined%${delimiter}}"
+# }
 
-quote_items() {
-  items=()
-  while (("$#")); do
-    items+=( "\"${1}\"" )
-    shift 1
-  done 
-  echo "${items[@]}"
-}
+# quote_items() {
+#   items=()
+#   while (("$#")); do
+#     items+=( "\"${1}\"" )
+#     shift 1
+#   done 
+#   echo "${items[@]}"
+# }
 
 
 # MARK - Usage
@@ -137,9 +141,9 @@ trap cleanup EXIT
 
 # Output
 echo >&2 "Release Tag: ${release_tag}"
-echo >&2 "Tools: $( to_delim_str ", " "${tools[@]}" )"
-echo >&2 "Platforms: $( to_delim_str ", " "${platforms[@]}" )"
-echo >&2 "Arches: $( to_delim_str ", " "${arches[@]}" )"
+echo >&2 "Tools: $( join_by ", " "${tools[@]}" )"
+echo >&2 "Platforms: $( join_by ", " "${platforms[@]}" )"
+echo >&2 "Arches: $( join_by ", " "${arches[@]}" )"
 
 # Prepare asset filter regex
 asset_regex='^('"$( IFS='|'; echo "${tools[*]}" )"')-'
@@ -170,14 +174,14 @@ for asset_base64_json in "${assets[@]}" ; do
 done
 
 # Combine the entries into a newline delimited string
-asset_sha256_values_str="$( to_delim_str $'\n' "${asset_sha256_values[@]}" )"
+asset_sha256_values_str="$( join_by $'\n' "${asset_sha256_values[@]}" )"
 
 # Create comma separated list
 # quoted_tools=( $(quote_items "${tools[@]}") )
 # tools_str="$( to_delim_str ", " "${quoted_tools[@]}" )"
-tools_str="$( to_delim_str ", " $(quote_items "${tools[@]}") )"
-platforms_str="$( to_delim_str ", " $(quote_items "${platforms[@]}") )"
-arches_str="$( to_delim_str ", " $(quote_items "${arches[@]}") )"
+tools_str="$( join_by ", " $(double_quote_items "${tools[@]}") )"
+platforms_str="$( join_by ", " $(double_quote_items "${platforms[@]}") )"
+arches_str="$( join_by ", " $(double_quote_items "${arches[@]}") )"
 # platforms_str="$( to_delim_str ", " "\"${platforms[@]}\"" )"
 # arches_str="$( to_delim_str ", " "\"${arches[@]}\"" )"
 

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -18,6 +18,34 @@ fail_sh="$(rlocation "${fail_sh_location}")" || \
   (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
 source "${fail_sh}"
 
+env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
+env_sh="$(rlocation "${env_sh_location}")" || \
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+source "${env_sh}"
+
+
+# MARK - Check for Required Software
+
+is_installed gh || fail "Could not find Github CLI (gh)."
+is_installed jq || fail "Could not find jq for JSON parsing."
+is_installed shasum || fail "Could not find shasum."
+
+
+# MARK - Usage
+
+get_usage() {
+  local utility="$(basename "${BASH_SOURCE[0]}")"
+  echo "$(cat <<-EOF
+Execute a Github Action workflow to create a relase with the specified tag.
+
+Usage:
+${utility} [OPTION] [<tag>]
+
+Options:
+  <tag>               The release tag.
+EOF
+  )"
+}
 
 # MARK - Process Args
 
@@ -34,3 +62,71 @@ while (("$#")); do
       ;;
   esac
 done
+
+[[ ${#args[@]} > 0 ]] && release_tag="${args[0]}"
+
+# MARK - Query for buildtool release info
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+# Determine which release to retrieve
+release_query_suffix="latest"
+[[ -n "${release_tag:-}" ]] && release_query_suffix="tags/${release_tag}"
+
+# Execute the query
+release_query_cmd=(gh api -X GET "repos/bazelbuild/buildtools/releases/${release_query_suffix}")
+release_query_result="$( "${release_query_cmd[@]}" )"
+
+# Get the release tag
+release_tag="$( echo "${release_query_result}" | jq -r '.tag_name' )"
+
+# Create a download directory
+download_dir="$( mktemp -d )"
+cleanup() {
+  rm -rf "${download_dir}"
+}
+trap cleanup EXIT
+
+# Download the assets and generate the sums.
+echo "Downloading the assets for ${release_tag}."
+asset_sha256_values=()
+assets=( $(echo "${release_query_result}" | jq -r -c '.assets[] | @base64') )
+for asset_base64_json in "${assets[@]}" ; do
+  asset_json="$( echo ${asset_base64_json} | base64 --decode )"
+  asset_name="$( echo "${asset_json}" | jq -r '.name' )"
+  [[ "${asset_name}" =~ ^(buildifier|buildozer)- ]] || continue
+
+  # Download the asset
+  echo >&2 "Downloading ${asset_name}..."
+  asset_url="$( echo "${asset_json}" | jq -r '.browser_download_url' )"
+  download_path="${download_dir}/${asset_name}"
+  curl -s -S -L -o "${download_path}" "${asset_url}"
+
+  # Calcuate the SHA256
+  asset_sha256="$( cat "${download_path}" | shasum -a 256 | awk '{print $1;}' )"
+  echo >&2 "SHA256 for ${asset_name}: ${asset_sha256}"
+
+  # Create the sha256_values entry; the '%.*' in asset_name expansion will strip the extension for the file.
+  asset_key="$( echo "${asset_name%.*}" | sed -E -e 's/[-.]/_/g'  )"
+  asset_sha256_values+=( "            \"${asset_key}\": \"${asset_sha256}\"" )
+done
+
+# Combine the entries into a newline delimited string
+asset_sha256_values_str="$( IFS=$'\n'; echo "${asset_sha256_values[*]}" )"
+
+# Create the declaration
+assets_declaration="$(cat <<-EOF
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains", "buildtools_assets")
+
+buildifier_prebuilt_register_toolchains(
+    assets = buildtools_assets(
+        sha256_values = {
+${asset_sha256_values_str}
+        },
+        version = "${release_tag}",
+    ),
+)
+EOF
+)"
+
+echo "${assets_declaration}"

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+fail_sh_location=cgrindel_bazel_starlib/shlib/lib/fail.sh
+fail_sh="$(rlocation "${fail_sh_location}")" || \
+  (echo >&2 "Failed to locate ${fail_sh_location}" && exit 1)
+source "${fail_sh}"
+
+
+# MARK - Process Args
+
+args=()
+while (("$#")); do
+  case "${1}" in
+    "--help")
+      show_usage
+      exit 0
+      ;;
+    *)
+      args+=("${1}")
+      shift 1
+      ;;
+  esac
+done

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -100,6 +100,8 @@ done
 
 # MARK - Query for buildtool release info
 
+# Switch to the workspace directory. We do this so that the GitHub CLI has 
+# multiple avenues for authenticating. 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
 # Determine which release to retrieve

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -35,25 +35,6 @@ is_installed jq || fail "Could not find jq for JSON parsing."
 is_installed shasum || fail "Could not find shasum."
 
 
-# MARK - Functions
-
-# join_by() {
-#   local delimiter="${1}"
-#   shift 1
-#   printf -v joined '%s'"${delimiter}" "${@}"
-#   echo "${joined%${delimiter}}"
-# }
-
-# quote_items() {
-#   items=()
-#   while (("$#")); do
-#     items+=( "\"${1}\"" )
-#     shift 1
-#   done 
-#   echo "${items[@]}"
-# }
-
-
 # MARK - Usage
 
 get_usage() {
@@ -177,13 +158,9 @@ done
 asset_sha256_values_str="$( join_by $'\n' "${asset_sha256_values[@]}" )"
 
 # Create comma separated list
-# quoted_tools=( $(quote_items "${tools[@]}") )
-# tools_str="$( to_delim_str ", " "${quoted_tools[@]}" )"
 tools_str="$( join_by ", " $(double_quote_items "${tools[@]}") )"
 platforms_str="$( join_by ", " $(double_quote_items "${platforms[@]}") )"
 arches_str="$( join_by ", " $(double_quote_items "${arches[@]}") )"
-# platforms_str="$( to_delim_str ", " "\"${platforms[@]}\"" )"
-# arches_str="$( to_delim_str ", " "\"${arches[@]}\"" )"
 
 # Create the declaration
 assets_declaration="$(cat <<-EOF

--- a/tools/generate_assets_declaration.sh
+++ b/tools/generate_assets_declaration.sh
@@ -28,6 +28,7 @@ arrays_sh="$(rlocation "${arrays_sh_location}")" || \
   (echo >&2 "Failed to locate ${arrays_sh_location}" && exit 1)
 source "${arrays_sh}"
 
+
 # MARK - Check for Required Software
 
 is_installed gh || fail "Could not find Github CLI (gh)."
@@ -46,7 +47,18 @@ Usage:
 ${utility} [OPTION] [<tag>]
 
 Options:
-  <tag>               The release tag.
+  --help                 Show usage.
+  --verbose              Enables verbose output to stderr.
+  --reset_tools          Resets the list of tools.
+  --tool <tool>          Adds the specified tool to the list of tools to be 
+                         retrieved.
+  --reset_platforms      Resets the list of platforms.
+  --platform <platform>  Adds the specified platform to the list of platforms 
+                         to be retrieved.
+  --reset_arches         Resets the list of arches.
+  --arch <arch>          Adds the specified arch to the list of arches to be
+                         retrieved
+  <tag>                  The release tag.
 EOF
   )"
 }
@@ -94,6 +106,10 @@ while (("$#")); do
       ;;
   esac
 done
+
+[[ ${#tools[@]} > 0 ]] || usage_error "Expected at least one tool to be specified."
+[[ ${#platforms[@]} > 0 ]] || usage_error "Expected at least one platform to be specified."
+[[ ${#arches[@]} > 0 ]] || usage_error "Expected at least one arch to be specified."
 
 [[ ${#args[@]} > 0 ]] && release_tag="${args[0]}"
 


### PR DESCRIPTION
Closes keith/buildifier-prebuilt#5.

- Added `tools/generate_assets_declaration.sh` to generate the appropriate assets declaration for `buildtools`.
- Updated the `README.md` to include information on how to specify the version for `buildtools`.
- Updated the default `buildtools` version to 4.2.5.
- Added test declaration generation.